### PR TITLE
Add repo to metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl CPAN distribution LWP-Simple-REST
 
 0.08 2015-07-?? GONCALES
+    - Added [GithubMeta] to dist.ini, so the dist metadata will contain
+      the github repo.
     - Reformatted this file to have most recent entry first,
       and adjusted formatting to match CPAN::Changes::Spec.
 

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl CPAN distribution LWP-Simple-REST
 0.08 2015-07-?? GONCALES
     - Added [GithubMeta] to dist.ini, so the dist metadata will contain
       the github repo.
+    - Added [MetaJSON] to dist.ini, so releases will include a META.json file.
     - Reformatted this file to have most recent entry first,
       and adjusted formatting to match CPAN::Changes::Spec.
 

--- a/Changes
+++ b/Changes
@@ -1,20 +1,29 @@
-Revision history for LWP-Simple-REST
+Revision history for Perl CPAN distribution LWP-Simple-REST
 
-0.001    Date/time
-        First version, released on an unsuspecting world.
+0.08 2015-07-?? GONCALES
+    - Reformatted this file to have most recent entry first,
+      and adjusted formatting to match CPAN::Changes::Spec.
 
-0.002    Json requests and Fix broken code
-        Added Json requests and fix the old code
+0.07 2015-07-03 GONCALES
+    - Fix some test bugs
 
-0.003    Fix dependency issue
-        Fixed the missing dependency prerequisite issue 
+0.06 2015-02-14 RECSKY
 
-0.04    HEAD
-        This version includes the http_head method, allowing to send HTTP HEAD request to a server
-        Fixed the version
+0.05 2015-02-09 RECSKY
 
-0.05   -
+0.04 2014-11-13 GONCALES
+    - This version includes the http_head method,
+      allowing to send HTTP HEAD request to a server
+    - Fixed the version
 
-0.06   -
+0.004 2014-11-13 GONCALES
 
-0.07   Fix some test bugs
+0.003 2014-11-13 GONCALES
+    - Fixed the missing dependency prerequisite issue 
+
+0.002 2014-10-23 RECSKY
+    - Added Json requests and fix the old code
+
+0.001 2014-09-20 GONCALES
+    - First version, released on an unsuspecting world.
+

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = Italo Goncales
 copyright_year   = 2015
 
-version = 0.07
+version = 0.08
 
 [@Basic]
 
@@ -18,3 +18,5 @@ Data::Structure::Util   = 0
 Try::Tiny               = 0
 [Prereqs / TestRequires]
 HTTP::Server::Simple::CGI = 0
+
+[GithubMeta]

--- a/dist.ini
+++ b/dist.ini
@@ -19,4 +19,5 @@ Try::Tiny               = 0
 [Prereqs / TestRequires]
 HTTP::Server::Simple::CGI = 0
 
+[MetaJSON]
 [GithubMeta]


### PR DESCRIPTION
Hi Italo,

The main goal with this PR was to add `[GithubMeta]` to `dist.ini`, so that the repo would appear in the dist's metadata. Once that's on CPAN, MetaCPAN would show a link to the repo in the left sidebar, and other tools would find it too.

While there I added `[MetaJSON]`, so that the releases will include a `META.json` file when you release. The `META.json` file supports some recent metadata features not supported by `META.yml`, which is why it's good to include this.

I also tweaked the formatting of the `Changes` file, to match the most widely used format.

Cheers,
Neil
